### PR TITLE
Switched to CHI to replace outdated Cache::FileCache

### DIFF
--- a/Bundle-Business-Shipping/lib/Bundle/Business/Shipping.pm
+++ b/Bundle-Business-Shipping/lib/Bundle/Business/Shipping.pm
@@ -22,7 +22,7 @@ Business::Shipping
 
 Business::Shipping::DataFiles
 
-Cache::FileCache
+CHI
 
 Class::MethodMaker::Engine
 

--- a/Bundle-Business-Shipping/lib/Bundle/Business/Shipping/UPS_Online.pm
+++ b/Bundle-Business-Shipping/lib/Bundle/Business/Shipping/UPS_Online.pm
@@ -20,7 +20,7 @@ See the INSTALL file in Business::Shipping for more information.
 
 Bundle::Business::Shipping::Basic
 
-Cache::FileCache
+CHI
 
 Crypt::SSLeay
 

--- a/Bundle-Business-Shipping/lib/Bundle/Business/Shipping/USPS_Online.pm
+++ b/Bundle-Business-Shipping/lib/Bundle/Business/Shipping/USPS_Online.pm
@@ -20,7 +20,7 @@ See the INSTALL file in Business::Shipping for more information.
 
 Bundle::Business::Shipping::Basic
 
-Cache::FileCache
+CHI
 
 Crypt::SSLeay
 

--- a/Business-Shipping/CHANGELOG
+++ b/Business-Shipping/CHANGELOG
@@ -1,6 +1,12 @@
 Revision history for Business::Shipping
 =======================================
 
+3.1.0 February 26, 2011
+
+    * Switched to CHI to replace outdated Cache::FileCache [JT Smith].
+    * Added cache_config to RateRequest and Tracking so developer can make use of any of the CHI drivers. [JT Smith]
+    * Fixed failing test for 'Airmail Parcel Post' in 210-USPS_Online-basic.t [JT Smith].
+
 
 3.0.0  February 12, 2011
 

--- a/Business-Shipping/INSTALL
+++ b/Business-Shipping/INSTALL
@@ -55,7 +55,7 @@ All required modules
     the combined list for all shippers:
 
      Business::Shipping::DataFiles (any)
-     Cache::FileCache (any)
+     CHI (0.39)
      Any::Moose (any)
      Config::IniFiles (any)
      Crypt::SSLeay (any)

--- a/Business-Shipping/META.yml
+++ b/Business-Shipping/META.yml
@@ -11,7 +11,7 @@ requires:
     Log::Log4perl:    0
     Test::More:       0.4
 recommends:
-    Cache::FileCache  0
+    CHI  0.39
     Crypt::SSLeay     0
     LWP::UserAgent    0
     XML::DOM          0

--- a/Business-Shipping/README
+++ b/Business-Shipping/README
@@ -112,7 +112,7 @@ OPTIONAL MODULES
     The following modules are used by online rate estimation and tracking.
     See INSTALL.
 
-     Cache::FileCache (any)
+     CHI (0.39)
      Crypt::SSLeay (any)
      LWP::UserAgent (any)
      XML::DOM (any)

--- a/Business-Shipping/UserTag/business-shipping.tag
+++ b/Business-Shipping/UserTag/business-shipping.tag
@@ -50,7 +50,7 @@ The following modules are required for offline UPS rate estimation.  See doc/INS
 
 The following modules are used by online rate estimation and tracking.  See doc/INSTALL.
 
- Cache::FileCache (any)
+ CHI (0.39)
  Crypt::SSLeay (any)
  LWP::UserAgent (any)
  XML::DOM (any)

--- a/Business-Shipping/doc/INSTALL.html
+++ b/Business-Shipping/doc/INSTALL.html
@@ -103,7 +103,7 @@ tarball, execute the following:</p>
 combined list for all shippers:</p>
 <pre>
  Business::Shipping::DataFiles (any)
- Cache::FileCache (any)
+ CHI (0.39)
  Any::Moose (any)
  Config::IniFiles (any)
  Crypt::SSLeay (any)

--- a/Business-Shipping/doc/INSTALL.pod
+++ b/Business-Shipping/doc/INSTALL.pod
@@ -65,7 +65,7 @@ Each Bundle lists the required modules for each shipper type.  Here is the
 combined list for all shippers:
 
  Business::Shipping::DataFiles (any)
- Cache::FileCache (any)
+ CHI (0.39)
  Any::Moose (any)
  Config::IniFiles (any)
  Crypt::SSLeay (any)

--- a/Business-Shipping/doc/INSTALL.txt
+++ b/Business-Shipping/doc/INSTALL.txt
@@ -55,7 +55,7 @@ All required modules
     the combined list for all shippers:
 
      Business::Shipping::DataFiles (any)
-     Cache::FileCache (any)
+     CHI (0.39)
      Any::Moose (any)
      Config::IniFiles (any)
      Crypt::SSLeay (any)

--- a/Business-Shipping/doc/README.html
+++ b/Business-Shipping/doc/README.html
@@ -212,7 +212,7 @@ For example:</pre>
 <p>The following modules are used by online rate estimation and tracking.  See 
 INSTALL.</p>
 <pre>
- Cache::FileCache (any)
+ CHI (0.39)
  Crypt::SSLeay (any)
  LWP::UserAgent (any)
  XML::DOM (any)

--- a/Business-Shipping/doc/README.txt
+++ b/Business-Shipping/doc/README.txt
@@ -112,7 +112,7 @@ OPTIONAL MODULES
     The following modules are used by online rate estimation and tracking.
     See INSTALL.
 
-     Cache::FileCache (any)
+     CHI (0.39)
      Crypt::SSLeay (any)
      LWP::UserAgent (any)
      XML::DOM (any)

--- a/Business-Shipping/lib/Business/Shipping.pm
+++ b/Business-Shipping/lib/Business/Shipping.pm
@@ -151,7 +151,7 @@ For UPS offline rate estimation:
 The following modules are used by online rate estimation and tracking.  See 
 INSTALL.
 
- Cache::FileCache (any)
+ CHI (0.39)
  Crypt::SSLeay (any)
  LWP::UserAgent (any)
  XML::DOM (any)

--- a/Business-Shipping/lib/Business/Shipping/Config.pm
+++ b/Business-Shipping/lib/Business/Shipping/Config.pm
@@ -238,7 +238,7 @@ sub get_req_mod {
         ],
         'UPS_Online' => [
             qw/
-                Cache::FileCache
+                CHI
                 Crypt::SSLeay
                 Date::Parse
                 LWP::UserAgent
@@ -248,7 +248,7 @@ sub get_req_mod {
         ],
         'USPS_Online' => [
             qw/
-                Cache::FileCache
+                CHI
                 Crypt::SSLeay
                 Date::Parse
                 LWP::UserAgent

--- a/Business-Shipping/lib/Business/Shipping/RateRequest.pm
+++ b/Business-Shipping/lib/Business/Shipping/RateRequest.pm
@@ -28,8 +28,15 @@ Boolean.  1 = Rate Request was successful.
 
 =head2 $rate_request->cache()
 
-Boolean.  1 = Save results using Cache::FileCache, and reload them if an 
+Boolean.  1 = Save results using CHI, and reload them if an 
 identical request is made later.  See submit() for implementation details.
+
+=head2 $rate_request->cache_config()
+
+Allows configuration of L<CHI> cache. Pass it a hash reference of a CHI config. Defaults to C<{driver => 'File'}>.
+
+ $rate_request->cache_config({ driver => 'Memory', global => 1 });
+
 
 =head2 $rate_request->invalid()
 
@@ -75,6 +82,7 @@ Additional keys may be added by the shipper class.
 =cut
 
 has 'cache'               => (is => 'rw', isa => 'Str');
+has 'cache_config'        => (is => 'rw', isa => 'HashRef', default => sub { { driver => 'File' } });
 has 'invalid'             => (is => 'rw', isa => 'Str');
 has 'shipper'             => (is => 'rw', isa => 'Str');
 has 'results'             => (is => 'rw', isa => 'ArrayRef');
@@ -145,7 +153,7 @@ sub execute {
     $self->validate() or return;
     if ($self->cache()) {
         trace('cache enabled');
-        my $cache = Cache::FileCache->new();
+        my $cache = CHI->new(%{$self->cache_config});
 
         my $key = $self->gen_unique_key();
         info "cache key = $key\n";
@@ -263,7 +271,7 @@ sub execute {
   # TODO: Allow setting of cache properties (time limit, enable/disable, etc.)
   #
         my $key       = $self->gen_unique_key();
-        my $new_cache = Cache::FileCache->new();
+        my $new_cache = CHI->new(%{$self->cache_config});
         $new_cache->set($key, $results, "2 days");
     }
     else {

--- a/Business-Shipping/lib/Business/Shipping/RateRequest/Online.pm
+++ b/Business-Shipping/lib/Business/Shipping/RateRequest/Online.pm
@@ -12,7 +12,7 @@ use Any::Moose;
 use Business::Shipping::Logging;
 use XML::Simple;
 use LWP::UserAgent;
-use Cache::FileCache;
+use CHI;
 use version; our $VERSION = qv('400');
 
 extends 'Business::Shipping::RateRequest';

--- a/Business-Shipping/lib/Business/Shipping/UPS_Online/RateRequest.pm
+++ b/Business-Shipping/lib/Business/Shipping/UPS_Online/RateRequest.pm
@@ -81,7 +81,7 @@ use Business::Shipping::UPS_Online::Package;
 use Business::Shipping::UPS_Online::Shipment;
 use Business::Shipping::Util;
 use XML::Simple 2.05;
-use Cache::FileCache;
+use CHI;
 use LWP::UserAgent;
 use POSIX ('strftime');
 use version; our $VERSION = qv('400');

--- a/Business-Shipping/t/112-FileCache.t
+++ b/Business-Shipping/t/112-FileCache.t
@@ -1,17 +1,17 @@
 #!/bin/env perl
 
-# Simulate the way that Cache::FileCache is used.
+# Simulate the way that CHI is used.
 
 use strict;
 use warnings;
 use Test::More;
 
-eval { require Cache::FileCache; };
-plan skip_all => 'Cache::FileCache not installed.' if $@;
+eval { require CHI; };
+plan skip_all => 'CHI not installed.' if $@;
 plan 'no_plan';
-import Cache::FileCache;
+import CHI;
 
-my $cache = Cache::FileCache->new;
+my $cache = CHI->new(driver => 'File');
 my $key   = join("|", ('Parcel Post', 'Germany', '5', 'Package'));
 my $rate  = $cache->get($key);
 
@@ -21,4 +21,4 @@ if (not defined $rate) {
     $cache->set($key, $rate, "30 minutes");
 }
 
-ok(1, 'Cache::FileCache works as expected.');
+ok(1, 'CHI works as expected.');

--- a/Business-Shipping/t/210-USPS_Online-basic.t
+++ b/Business-Shipping/t/210-USPS_Online-basic.t
@@ -225,7 +225,7 @@ if (0) {
     my $shipment = test(
         'cache'      => 1,
         'test_mode'  => 0,
-        'service'    => 'Airmail Parcel Post',
+        'service'    => 'Express Mail International',
         'weight'     => 1,
         'ounces'     => 0,
         'mail_type'  => 'Package',
@@ -236,7 +236,7 @@ if (0) {
     my $shipment2 = test(
         'cache'      => 1,
         'test_mode'  => 0,
-        'service'    => 'Airmail Parcel Post',
+        'service'    => 'Express Mail International',
         'weight'     => 10,
         'ounces'     => 0,
         'mail_type'  => 'Package',


### PR DESCRIPTION
I've converted Business::Shipping to use CHI instead of Cache::FileCache. I've also made it configurable by setting $rate_request->cache_config or $tracking->cache_config. I've also updated all docs and tests to reflect this change, and created the CHANGELOG entries. So if you approve, you should just be able to pull into your repo and push it to PAUSE.

I also fixed a failing test in 210-USPS_Online-basic.t. It was using Airmail Parcel Post, which USPS said didn't exist. So I switched it to Express Mail International. I hope that's ok.
